### PR TITLE
DD-WRT monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # plasma-applet-network-monitor
 List applet for monitoring active network connections.
+This is a fork of https://github.com/kotelnik/plasma-applet-network-monitor adding the functionality of monitor the WAN network connection of a DD-WRT router

--- a/org.kde.networkMonitor/contents/code/helper.js
+++ b/org.kde.networkMonitor/contents/code/helper.js
@@ -7,6 +7,7 @@ var SpeedType = {
     Upload: 2
 }
 
+
 function addSpeedData(speed, model, graphGranularity, itemHeight, scaleCoeficient) {
     
     // initial fill up
@@ -96,3 +97,4 @@ function recalculate(model, oldMaxBytes) {
         model.setProperty(i, 'graphItemHeight', itemHeight * recalculateNumber)
     }
 }
+

--- a/org.kde.networkMonitor/contents/config/main.xml
+++ b/org.kde.networkMonitor/contents/config/main.xml
@@ -7,7 +7,19 @@
 
     <group name="General">
         <entry name="showLo" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="showDdWrt" type="Bool">
             <default>true</default>
+        </entry>
+        <entry name="ddwrtHost" type="String">
+            <default>http://192.168.178.1</default>
+        </entry>
+        <entry name="ddwrtUser" type="String">
+            <default>admin</default>
+        </entry>
+        <entry name="ddwrtPassword" type="String">
+            <default></default>
         </entry>
         <entry name="updateInterval" type="Double">
             <default>1.0</default>

--- a/org.kde.networkMonitor/contents/ui/DdWrtClient.qml
+++ b/org.kde.networkMonitor/contents/ui/DdWrtClient.qml
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2015  Martin Kotelnik <clearmartin@seznam.cz>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http: //www.gnu.org/licenses/>.
+ */
+import QtQuick 2.2
+import QtQuick.Layouts 1.1
+import QtGraphicalEffects 1.0
+import org.kde.plasma.core 2.0 as PlasmaCore
+
+
+Item {
+    id: ddwrtClient
+    
+    width: 0
+    height: 0
+
+    //! This function fetches the players last matches from the dota2 webapi
+    // DD-WRT hacky temporaries
+    property double ddwrt_din: 0
+    property double ddwrt_dout: 0
+    property double last_ifin: 0
+    property double last_ifout: 0
+    property double last_ugmt: 0
+
+    function queryDdWrt() {
+        var request = new XMLHttpRequest();
+        request.onreadystatechange = function() {
+            if (request.readyState === XMLHttpRequest.DONE && request.status === 200) {
+                var document = request.responseText.replace(/\s\s+/g, ' ')
+
+                var data=request.responseText.split("\n");
+                var dateStr=data[0];
+                //fake timezone cause the real value might confuse JS
+                dateStr=dateStr.replace(/ [A-Z]+ /, ' ');
+                var ugmt=(Date.parse(dateStr))/1000;
+
+                data=data[1].split(/\s+|:/);
+                while (data[0]!=parseInt(data[0])) {
+                        data.shift();
+
+                        if (0==data.length)
+                            return 0;
+                }
+                var ifin=parseInt(data[0]);
+                var ifout=parseInt(data[8]);
+
+                var diff_ugmt  = ugmt - last_ugmt;
+                var diff_ifin  = ifin - last_ifin;
+                var diff_ifout = ifout - last_ifout;
+
+                if (diff_ugmt == 0)
+                    diff_ugmt = 1;  // avoid division by zero
+
+                last_ugmt = ugmt;
+                last_ifin = ifin;
+                last_ifout = ifout;
+
+                ddwrt_din = diff_ifin / diff_ugmt; // B / sec
+                ddwrt_dout = diff_ifout / diff_ugmt; // B / sec
+            }
+        }
+
+        var url = ddwrtHost + "/fetchif.cgi?vlan2"
+        request.open('GET', url)
+        request.setRequestHeader("Authorization", "Basic " + ddwrtKey)
+        request.send()
+    }
+
+    Timer {
+        interval: 1000;
+        running: true;
+        repeat: true
+        onTriggered: {
+            queryDdWrt()
+        }
+    }
+}

--- a/org.kde.networkMonitor/contents/ui/config/ConfigFilter.qml
+++ b/org.kde.networkMonitor/contents/ui/config/ConfigFilter.qml
@@ -9,7 +9,8 @@ Item {
     property int textfieldWidth: 200
     
     property alias cfg_showLo: showLo.checked
-    
+    property alias cfg_showDdWrt: showDdWrt.checked
+
     property int cfg_deviceFilterType
     property alias cfg_deviceWhiteListRegexp: deviceWhiteListRegexp.text
     property alias cfg_deviceBlackListRegexp: deviceBlackListRegexp.text
@@ -39,6 +40,24 @@ Item {
     GridLayout {
         Layout.fillWidth: true
         columns: 3
+
+        Item {
+            width: 2
+            height: 10
+            Layout.columnSpan: 3
+        }
+
+        CheckBox {
+            id: showDdWrt
+            text: i18n('Show DD-WRT')
+            Layout.columnSpan: 3
+        }
+
+        Item {
+            width: 2
+            height: 10
+            Layout.columnSpan: 3
+        }
         
         CheckBox {
             id: showLo

--- a/org.kde.networkMonitor/contents/ui/config/ConfigGeneral.qml
+++ b/org.kde.networkMonitor/contents/ui/config/ConfigGeneral.qml
@@ -38,12 +38,6 @@ Item {
             placeholderText: i18n('http://192.168.178.23')
         }
         
-        Item {
-            width: 2
-            height: 10
-            Layout.columnSpan: 2
-        }
-
         Label {
             text: i18n('DD-WRT user:')
             Layout.alignment: Qt.AlignRight
@@ -54,12 +48,6 @@ Item {
             placeholderText: i18n('admin')
         }
 
-        Item {
-            width: 2
-            height: 10
-            Layout.columnSpan: 2
-        }
-
         Label {
             text: i18n('DD-WRT password:')
             Layout.alignment: Qt.AlignRight
@@ -68,12 +56,6 @@ Item {
         TextField {
             id: ddwrtPassword
             placeholderText: i18n('password')
-        }
-
-        Item {
-            width: 2
-            height: 10
-            Layout.columnSpan: 2
         }
         
         CheckBox {

--- a/org.kde.networkMonitor/contents/ui/config/ConfigGeneral.qml
+++ b/org.kde.networkMonitor/contents/ui/config/ConfigGeneral.qml
@@ -8,6 +8,9 @@ Item {
 
     property alias cfg_updateInterval: updateIntervalSpinBox.value
     property alias cfg_historyGraphsEnabled: historyGraphsEnabled.checked
+    property alias cfg_ddwrtHost: ddwrtHost.text
+    property alias cfg_ddwrtUser: ddwrtUser.text
+    property alias cfg_ddwrtPassword: ddwrtPassword.text
 
     GridLayout {
         Layout.fillWidth: true
@@ -24,7 +27,49 @@ Item {
             minimumValue: 0.1
             suffix: i18nc('Abbreviation for seconds', 's')
         }
+
+        Label {
+            text: i18n('DD-WRT host:')
+            Layout.alignment: Qt.AlignRight
+        }
+
+        TextField {
+            id: ddwrtHost
+            placeholderText: i18n('http://192.168.178.23')
+        }
         
+        Item {
+            width: 2
+            height: 10
+            Layout.columnSpan: 2
+        }
+
+        Label {
+            text: i18n('DD-WRT user:')
+            Layout.alignment: Qt.AlignRight
+        }
+
+        TextField {
+            id: ddwrtUser
+            placeholderText: i18n('admin')
+        }
+
+        Item {
+            width: 2
+            height: 10
+            Layout.columnSpan: 2
+        }
+
+        Label {
+            text: i18n('DD-WRT password:')
+            Layout.alignment: Qt.AlignRight
+        }
+
+        TextField {
+            id: ddwrtPassword
+            placeholderText: i18n('password')
+        }
+
         Item {
             width: 2
             height: 10

--- a/org.kde.networkMonitor/contents/ui/main.qml
+++ b/org.kde.networkMonitor/contents/ui/main.qml
@@ -25,19 +25,22 @@ Item {
     
     // general settings
     property bool showLo: plasmoid.configuration.showLo
+    property bool showDdWrt: plasmoid.configuration.showDdWrt
     property double updateInterval: plasmoid.configuration.updateInterval * 1000
     
     // filter settings
     property int deviceFilterType: plasmoid.configuration.deviceFilterType
     property string deviceWhiteListRegexp: '^(' + plasmoid.configuration.deviceWhiteListRegexp + ')$'
     property string deviceBlackListRegexp: '^(?!(' + plasmoid.configuration.deviceBlackListRegexp + '))'
-    
+    property string ddwrtHost: plasmoid.configuration.ddwrtHost
+    property string ddwrtKey: Qt.atob(plasmoid.configuration.ddWrtUser + ":" + plasmoid.configuration.ddWrtPassword)
+
     // appearance settings
     property double iconOpacity: plasmoid.configuration.iconOpacity
     property double iconBlur: plasmoid.configuration.iconBlur
     property bool showDeviceNames: plasmoid.configuration.showDeviceNames
     property bool historyGraphsEnabled: plasmoid.configuration.historyGraphsEnabled
-    
+
     //
     // sizing and spacing
     //
@@ -104,7 +107,7 @@ Item {
         main.width = widgetWidth
         main.height = widgetHeight
     }
-    
+
     anchors.fill: parent
     
     PlasmaNM.NetworkModel {
@@ -125,18 +128,30 @@ Item {
         sourceModel: activeNetworksModel
         onCountChanged: devicesChanged()
     }
+
+    DdWrtClient {
+        id: ddWrt
+    }
     
     ListModel {
         id: networkDevicesModel
     }
-    
+
     function devicesChanged() {
         networkDevicesModel.clear()
+
+        if (showDdWrt) {
+            networkDevicesModel.append({
+                DeviceName: 'ddwrt',
+                ConnectionIcon: ''})
+        }
+
         if (showLo) {
             networkDevicesModel.append({
                 DeviceName: 'lo',
                 ConnectionIcon: ''
             })
+
         } else if (filteredByNameModel.count === 0) {
             networkDevicesModel.append({
                 DeviceName: '_',
@@ -154,7 +169,8 @@ Item {
     }
     
     onShowLoChanged: devicesChanged()
-    
+    onShowDdWrtChanged: devicesChanged()
+
     GridLayout {
         columns: gridColumns
         columnSpacing: itemMargin

--- a/org.kde.networkMonitor/contents/ui/main.qml
+++ b/org.kde.networkMonitor/contents/ui/main.qml
@@ -152,7 +152,7 @@ Item {
                 ConnectionIcon: ''
             })
 
-        } else if (filteredByNameModel.count === 0) {
+        } else if (filteredByNameModel.count === 0 && !showDdWrt) {
             networkDevicesModel.append({
                 DeviceName: '_',
                 ConnectionIcon: ''


### PR DESCRIPTION
Hi!

I added support for monitoring DD-WRT WAN traffics.
These routers basically over an API to access traffic informations. With that information I generate down- and upload speedinfos that I can then use in the ActiveConnection QML Item.

I initially thought that I had to do this in a hacky way, but I believe that the implementation is not too ugly. The only thing that really concern me, is that I have to fake a local device for my actual ddwrt device in ActiveConnection - I fake that the ddwrt monitor is actually the loopback device.

I am aware that this implementation is only for a small user group as one has to have a DD-WRT router to gain anything. However, maybe you find this useful.
